### PR TITLE
Added option to center tombstone on circle

### DIFF
--- a/shapes.scad
+++ b/shapes.scad
@@ -85,22 +85,23 @@ module rounded_square_2(vector, c1, c2, c3, c4, r = 0, center = false) {
     }
 }
 
-module tombstone_2d(vector) {
+module tombstone_2d(vector, center_on_circle = false) {
 	x = vector[0];
 	y = vector[1];
 
     assert(x >= y/2, "X dimension must be at least half Y dimension.");
 
-    rounded_square_2([x, y], c2 = y/2, c3 = y/2);
+    translate([center_on_circle ? -x + y/2 : 0, center_on_circle ? -y/2 : 0])
+        rounded_square_2([x, y], c2 = y/2, c3 = y/2);
 }
 
-module tombstone(vector) {
+module tombstone(vector, center_on_circle = false) {
 	x = vector[0];
 	y = vector[1];
     z = vector[2];
 
     linear_extrude(z)
-        tombstone_2d([x, y]);
+        tombstone_2d([x, y], center_on_circle);
 }
 
 function arc_points(r, start_angle, stop_angle) =


### PR DESCRIPTION
Added an option to center the tombstone shapes on the circle part, which is common in many of its usages.